### PR TITLE
Update pigeon.jsp

### DIFF
--- a/src/main/resources/webapps/hdfs/pigeon.jsp
+++ b/src/main/resources/webapps/hdfs/pigeon.jsp
@@ -9,7 +9,7 @@
   import="java.io.PrintStream"
   import="java.io.IOException"
   import="org.apache.hadoop.http.HtmlQuoting"
-  import="org.apache.hadoop.hdfs.server.namenode.JspHelper"
+  import="org.apache.hadoop.hdfs.server.common.JspHelper"
   import="org.apache.hadoop.conf.Configuration"
   import="org.apache.hadoop.security.UserGroupInformation"
   import="org.apache.hadoop.fs.*"
@@ -20,7 +20,6 @@
 %>
 
 <%! private static final long serialVersionUID = 1L;%>
-<%! static JspHelper jspHelper = new JspHelper(); %>
 
 <%!
 private void listDirectory(HttpServletRequest request, JspWriter out,


### PR DESCRIPTION
hadoop 2.x JspHelper 's package is changed. org.apache.hadoop.hdfs.server.common.JspHelper constructor method is privated.
